### PR TITLE
Fix "invalid escape sequence" SyntaxError

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -345,7 +345,7 @@ def readStringFromStream(stream):
                            b_("t") : b_("\t"),
                            b_("b") : b_("\b"),
                            b_("f") : b_("\f"),
-                           b_("c") : b_("\c"),
+                           b_("c") : b_(r"\c"),
                            b_("(") : b_("("),
                            b_(")") : b_(")"),
                            b_("/") : b_("/"),


### PR DESCRIPTION
This happens when the library is used with `-Werror`, since `\c` is not a valid Python escape sequence.